### PR TITLE
feat(config): dev/prod profiles for API & ML + env-driven configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+## [Unreleased]
+### Added
+- Dev/prod profiles for API and ML (env-driven configuration for ports, CORS, log levels, ML base URL).
+- Docker Compose profiles (`dev`, `prod`) with environment wiring.
+- Documentation updates: README (Quick start, profiles), ADR-0001.
+
+### Changed
+- Centralized configuration via `application-*.yml` (API) and env vars (ML).
+
+### Security
+- CORS allowlist is explicit and environment-configurable for prod.

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -35,10 +35,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-actuator</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-json</artifactId>
         </dependency>
         <dependency>
@@ -61,24 +57,35 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.6.0</version>
         </dependency>
-            <dependency>
-              <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>${logback.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>ch.qos.logback</groupId><artifactId>logback-core</artifactId><version>${logback.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.tomcat.embed</groupId><artifactId>tomcat-embed-core</artifactId><version>${tomcat.version}</version>
-            </dependency>
-            <dependency>
-              <groupId>org.xmlunit</groupId><artifactId>xmlunit-core</artifactId><version>${xmlunit.version}</version><scope>test</scope>
-            </dependency>
-            <dependency>
-              <groupId>net.minidev</groupId><artifactId>json-smart</artifactId><version>${json-smart.version}</version><scope>test</scope>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><version>${commons-lang3.version}</version>
-            </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId><artifactId>logback-classic</artifactId><version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId><artifactId>logback-core</artifactId><version>${logback.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.tomcat.embed</groupId><artifactId>tomcat-embed-core</artifactId><version>${tomcat.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xmlunit</groupId><artifactId>xmlunit-core</artifactId><version>${xmlunit.version}</version><scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId><artifactId>json-smart</artifactId><version>${json-smart.version}</version><scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId><artifactId>commons-lang3</artifactId><version>${commons-lang3.version}</version>
+        </dependency>
+          <!-- Observability -->
+         <dependency>
+           <groupId>org.springframework.boot</groupId>
+           <artifactId>spring-boot-starter-actuator</artifactId>
+         </dependency>
+         <!-- Logback JSON encoder -->
+         <dependency>
+           <groupId>net.logstash.logback</groupId>
+           <artifactId>logstash-logback-encoder</artifactId>
+           <version>7.4</version>
+         </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/api/src/main/java/com/tes/api/config/WebConfig.java
+++ b/api/src/main/java/com/tes/api/config/WebConfig.java
@@ -1,22 +1,30 @@
 package com.tes.api.config;
 
-import org.springframework.context.annotation.Bean;
+
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.cors.*;
-import org.springframework.web.filter.CorsFilter;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig {
-    @Bean
-    public CorsFilter corsFilter() {
-        CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("http://localhost:5173");
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
-        config.setAllowCredentials(true);
+public class WebConfig implements WebMvcConfigurer {
 
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        source.registerCorsConfiguration("/**", config);
-        return new CorsFilter(source);
+    @Value("${cors.allowed-origins}")
+    private String allowedOrigins;
+
+    @Value("${cors.allowed-methods}")
+    private String allowedMethods;
+
+    @Value("${cors.allowed-headers}")
+    private String allowedHeaders;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(allowedOrigins.split(","))
+                .allowedMethods(allowedMethods.split(","))
+                .allowedHeaders(allowedHeaders.split(","))
+                .allowCredentials(false)
+                .maxAge(3600);
     }
 }

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -1,0 +1,30 @@
+server:
+  port: 8080
+
+tes:
+  ml:
+    base-url: http://ml:8000        # compose dev
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,prometheus"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+  server:
+    port: 8081                      # отдельный порт актуаторов (удобно в dev)
+
+logging:
+  level:
+    root: INFO
+    org.springframework.web: INFO
+  pattern:
+    correlation: "%X{requestId:-}"
+
+cors:
+  allowed-origins: "http://localhost:5173,http://localhost:3000"
+  allowed-methods: "GET,POST,OPTIONS"
+  allowed-headers: "*"

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -1,0 +1,27 @@
+server:
+  port: ${API_PORT:8080}
+
+tes:
+  ml:
+    bas-url: ${ML_BASE_URL:http://ml:8000}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "health,info,prometheus"
+  endpoint:
+    health:
+      probes:
+        enabled: true
+
+logging:
+  level:
+    root: INFO
+  pattern:
+    correlation: "%X{requestId:-}"
+
+cors:
+  allowed-origins: ${ALLOWED_ORIGINS:https://tes.example.com}
+  allowed-methods: "GET,POST,OPTIONS"
+  allowed-headers: "*"

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,12 +1,11 @@
-server:
-  port: ${SERVER_PORT:8080}
-ml:
-  base-url: ${ML_BASE_URL:http://localhost:8000}
-management:
-  endpoints:
-    web:
-      exposure:
-        include: "health,info,metrics"
+
+#ml:
+#  base-url: ${ML_BASE_URL:http://localhost:8000}
+#management:
+#  endpoints:
+#    web:
+#      exposure:
+#        include: "health,info,metrics"
 springdoc:
   api-docs:
     path: /v3/api-docs
@@ -15,8 +14,14 @@ springdoc:
     display-request-duration: true
     tags-sorter: alpha
     operations-sorter: alpha
-cors:
-  allowed-origins: "http://localhost:5173"
-  allowed-methods: "GET,POST,OPTIONS"
-  allowed-headers: "*"
+#cors:
+#  allowed-origins: "http://localhost:5173"
+#  allowed-methods: "GET,POST,OPTIONS"
+#  allowed-headers: "*"
+
+spring:
+  application:
+    name: tes-api
+  profiles:
+    active: dev
 

--- a/api/src/main/resources/logback-spring.xml
+++ b/api/src/main/resources/logback-spring.xml
@@ -1,0 +1,25 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <timestamp/>
+                <pattern>
+                    <pattern>
+                        {
+                        "level": "%level",
+                        "logger": "%logger{36}",
+                        "thread": "%thread",
+                        "message": "%message",
+                        "requestId": "%mdc{requestId:-}",
+                        "app": "tes-api"
+                        }
+                    </pattern>
+                </pattern>
+                <stackTrace/>
+            </providers>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/docs/adr/ADR-0001-profiles-and-config.md
+++ b/docs/adr/ADR-0001-profiles-and-config.md
@@ -1,0 +1,18 @@
+# ADR-0001: Introduce dev/prod profiles and env-driven configuration
+
+## Status
+Accepted (2025-08-25)
+
+## Context
+We need predictable local and production-like runs with secure defaults (CORS, ports, log levels) and zero code changes between environments.
+
+## Decision
+- API: Spring Boot profiles `dev` (default) and `prod`; split config into `application-dev.yml` and `application-prod.yml`.
+- ML: Environment-driven configuration for port, allowed origins, and version; CORS allowlist.
+- Infra: Docker Compose profiles `dev`/`prod` to wire services consistently.
+
+## Consequences
+- + Clear separation of local vs prod settings.
+- + Safer defaults (restrictive CORS in prod).
+- + Simpler ops via env vars.
+- ± Requires updating README and compose environment variables.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -29,10 +29,18 @@ services:
     ports:
       - "8080:8080"
       - "5005:5005"
+      - "8081:8081"
     environment:
-      - ML_BASE_URL=http://ml:8000
-      - SERVER_PORT=8080
+      - SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-dev}
+      - ALLOWED_ORIGINS=${ALLOWED_ORIGINS:-http://localhost:5173,http://localhost:3000}
+      - API_PORT=${API_PORT:-8080}
+      - ML_BASE_URL=${ML_BASE_URL:-http://ml:8000}
     restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "wget", "-qO-", "http://localhost:8081/actuator/health/readiness" ]
+      interval: 10s
+      timeout: 3s
+      retries: 5
 
   web:
     build: ../web

--- a/ml/requirements.txt
+++ b/ml/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.112,<1.0
 uvicorn>=0.30,<1.0
 numpy>=1.26,<3
 pyyaml>=6.0
+structlog


### PR DESCRIPTION
Purpose
Introduce explicit dev/prod profiles for API and ML to make local and production‑like runs predictable and secure by default.

Changes
	•	API:
	•	application.yml minimal bootstrap + application-dev.yml, application-prod.yml
	•	Env‑driven: API_PORT, ALLOWED_ORIGINS, ML_BASE_URL, log levels
	•	ML:
	•	Env‑driven: ML_PORT, ALLOWED_ORIGINS, ML_VERSION
	•	CORS allowlist from env
	•	Infra:
	•	infra/docker-compose.yml: profiles dev/prod, env wiring
	•	Docs:
	•	Updated README.md (Quick start, profiles, env, compose usage)
	•	CHANGELOG.md entry
	•	docs/adr/ADR-0001-profiles-and-config.md

Migration / Notes
	•	No breaking API changes.
	•	For local dev run:
	•	docker compose -f infra/docker-compose.yml up --build
	•	For production‑like run:
	•	SPRING_PROFILES_ACTIVE=prod ALLOWED_ORIGINS=https://tes.example.com docker compose -f infra/docker-compose.yml --profile prod up --build

Tests
	•	Smoke: API/ML start with respective profiles; UI works with CORS allowlist in dev.
	•	Verified env overrides for ports and origins.

Checklist
	•	Profiles active by default (dev)
	•	Env vars documented in README
	•	Compose --profile prod spins up without code changes
	•	No contract changes